### PR TITLE
Add timestamp to each log message

### DIFF
--- a/glfs-subvol/glfs-subvol
+++ b/glfs-subvol/glfs-subvol
@@ -35,7 +35,7 @@ LOCKPATH=/var/lock/glfs-subvol
 #-- Make an entry in the log file (if enabled)
 function log() {
     if [[ $DEBUG -gt 0 ]]; then
-        echo "[$TIME] $*" >> $DEBUGFILE
+        echo "$(date "+%b %d %T") [$TIME] $*" >> $DEBUGFILE
     fi
 }
 


### PR DESCRIPTION
Example of new format:
```
Mar 07 13:57:00 [1520449020.290372728] > init
Mar 07 13:57:00 [1520449020.290372728] < 0 {"status": "Failure", "message": " Unable to create /var/lock/glfs-subvol"}
```
The old "static" ts is still there to record the start time of the script and to allow un-threading of simultaneous execution. All we do is prepend the day and time to each log line.

Closes #19 