### PR TITLE
Add creator scripts for xfs project quotas.

### DIFF
--- a/volcreator/apply_xfs_quota.sh
+++ b/volcreator/apply_xfs_quota.sh
@@ -1,0 +1,68 @@
+#! /bin/bash
+# vim: set ts=4 sw=4 et :
+
+# Copyright 2018 Red Hat, Inc. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+function usage() {
+    echo "Usage: $0 <brick_base_path> <quota.dat>"
+}
+
+function getMntPoint() {
+    local orig="$1"
+    local mntpt="$orig"
+    while ! mountpoint -q "$mntpt"; do
+        if [ ! -e "$mntpt" ]; then
+            echo "NotFound"
+            return
+        fi
+        mntpt="${mntpt}/.."
+    done
+    realpath "$mntpt"
+}
+
+function setQuota() {
+    local projid="$1"
+    local cap_gb="$2"
+    local pathname="$3"
+    local mp
+    mp="$(getMntPoint "$3")"
+    if [ -d "$mp" ] && [ "$mp" != "NotFound" ]; then
+        #echo "Setting ${cap_gb}GB quota on $pathname as id $projid at mp: $mp"
+        xfs_quota -x -c "project -s -p $pathname $projid" "$mp"
+        xfs_quota -x -c "limit -p bhard=${cap_gb}g $projid" "$mp"
+    else
+        echo "mountpoint for $pathname not found"
+        exit 1
+    fi
+}
+
+base_path="$1"
+quotafile="$2"
+
+if [ $# -ne 2 ]; then usage; exit 1; fi
+
+if [ ! -e "$quotafile" ]; then
+    echo "Quota file not found: $quotafile"
+    exit 2
+fi
+
+if [ ! -d "$base_path" ]; then
+    echo "Brick base path not found: $base_path"
+    exit 2
+fi
+
+while read -r projid cap_gb subdir || [ -n "$subdir" ]; do
+    setQuota "$projid" "$cap_gb" "$base_path/$subdir"
+done < "$quotafile"

--- a/volcreator/creator_xfs_quota.sh
+++ b/volcreator/creator_xfs_quota.sh
@@ -1,0 +1,118 @@
+#! /bin/bash
+# vim: set ts=4 sw=4 et :
+
+# Copyright 2018 Red Hat, Inc. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+function usage() {
+    echo "Usage: $0 <server1:server2:...> <volume> <base_path> <quota_in_GB> <start> <end>"
+    echo "    0 <= start <= end <= 65535"
+}
+
+function tohexpath() {
+    local -i l1=$1/256
+    local -i l2=$1%256
+    printf '%02x/%02x' "$l1" "$l2"
+}
+
+function mkPvTemplate() {
+    local servers=$1
+    local volume=$2
+    local subdir=$3
+    local capacity=$4
+    local uuid=$5
+
+    local pv_name
+    pv_name=$(echo "${uuid}-${subdir}" | tr '/' '-')
+    cat - << EOT
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: "$pv_name"
+  labels:
+    cluster: "$(echo "$servers" | tr ':' '-')"
+    volume: "$volume"
+    subdir: "$(echo "$subdir" | tr '/' '-')"
+    supervol: "$uuid"
+spec:
+  capacity:
+    storage: $capacity
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: gluster-subvol
+  flexVolume:
+    driver: "rht/glfs-subvol"
+    options:
+      cluster: $servers
+      volume: $volume
+      dir: $subdir
+EOT
+}
+
+function mkQuotaCmd() {
+    local dir_idx=$1
+    local cap_gb=$2
+    # Since projid=0 is special in xfs, we add an offset of 100000 to the
+    # subdir index. Since we don't expect > 100000 quotas/subvols, this
+    # allows easy conversion by looking at the lower digits.
+    # Format for the file is 1 quota per line:
+    # projid cap_gb subdir
+    local projid=$((dir_idx + 100000))
+    local subdir
+    subdir="$(tohexpath "$i")"
+    echo "$projid $cap_gb $subdir"
+}
+
+
+
+servers=$1
+volume_name=$2
+base_path=$3
+volsize_gb=$4
+declare -i i_start=$5
+declare -i i_end=$6
+
+declare -i i=$i_start
+
+if [ $# -ne 6 ]; then usage; exit 1; fi
+if [ "$i" -lt 0 ]; then usage; exit 1; fi
+if [ "$i" -gt "$i_end" ]; then usage; exit 1; fi
+if [ "$i_end" -gt 65535 ]; then usage; exit 1; fi
+
+if [ ! -f "$base_path/supervol-uuid" ]; then
+    uuidgen -r > "$base_path/supervol-uuid"
+fi
+supervol_uuid=$(cat "$base_path/supervol-uuid")
+
+rm "$base_path/pvs-$i_start-$i_end.yml"
+while [ "$i" -le "$i_end" ]; do
+    subdir="$(tohexpath "$i")"
+    dir="$base_path/$subdir"
+    echo "creating: $dir ($i/$i_end)"
+    if ! mkdir -p "$dir"; then
+        echo "Unable to create $dir"
+        exit 2
+    fi
+    if ! chmod 777 "$dir"; then
+        echo "Unable to set permissions on $dir"
+        exit 2
+    fi
+    mkPvTemplate "$servers" "$volume_name" "$subdir" "${volsize_gb}Gi" "$supervol_uuid" >> "$base_path/pvs-$i_start-$i_end.yml"
+    mkQuotaCmd "$i" "$volsize_gb" >> "$base_path/quota-$i_start-$i_end.dat"
+    ((++i))
+done
+
+exit 0

--- a/volcreator/xfs_quota.md
+++ b/volcreator/xfs_quota.md
@@ -1,0 +1,66 @@
+# Using XFS project quotas instead of Gluster quotas
+
+Gluster's implementation of quotas tends to have high overhead for small-file
+workloads. In cases where straight replication is being used (no disperse), each
+brick will have the same view of a directory, and xfs quotas can be used at the
+brick level to constrain subdir space usage.
+
+The `creator_xfs_quota.sh` and `apply_xfs_quota.sh` scripts can be used to set
+up the subdir volumes in the same way as `creator.sh` is used to set up with
+Gluster quota.
+
+## Creating the subdirectories
+
+The `creator_xfs_quota.sh` script is used to create the subdirectories in the
+supervol, build the PV yaml file, and create a file that describes the xfs
+project quotas that need to be applied to the Gluster bricks.
+
+1. Mount the supervol
+   ```sh
+   $ mkdir /mnt/supervol00
+   $ mount -t glusterfs localhost:/supervol00 /mnt/supervol00
+   ```
+1. Create the subdirs. The following example is creating 5000 subvol PVs (0 --
+   4999).
+   ```sh
+   $ ./creator_xfs_quota.sh 172.31.80.251:172.31.87.134:172.31.93.163 supervol00 /mnt/supervol00/ 1 0 4999
+   ```
+
+The above steps will create the `pvs-0-4999.yml` containing the PV descriptions,
+and an additional file, `quota-0-4999.dat` that contains the quota information.
+
+## Applying the quotas
+
+The quotas need to be applied to each backing brick. Perform the following
+command on each brick:
+
+1. Copy or mount the quota dat file on each server.
+1. Apply the quotas, providing the root directory of the brick and the path to
+   the quota file
+   ```sh
+   $ ./apply_xfs_quota.sh /bricks/supervol00/brick /mnt/supervol00/quota-0-4999.dat
+   ```
+
+## Viewing quotas and usage
+
+The usage can be checked by logging into a server and running:
+```sh
+$ sudo xfs_quota -x -c 'report -p -a'
+Project quota on /bricks/supervol00 (/dev/mapper/supervol00-supervol00)
+                               Blocks
+Project ID       Used       Soft       Hard    Warn/Grace
+---------- --------------------------------------------------
+#0               9900          0          0     00 [--------]
+#100000        102400          0    1048576     00 [--------]
+#100001             0          0    1048576     00 [--------]
+#100002             0          0    1048576     00 [--------]
+#100003             0          0    1048576     00 [--------]
+#100004             0          0    1048576     00 [--------]
+...
+```
+
+The project id numbers correspond to the subdir indicies: Directory 0 maps to
+`00/00` which corresponds to project id 100000.
+
+In the above example, we see that `00/00` has used 100 MB of the 1 GB quota.
+Project id 0 is the default project and should be ignored.


### PR DESCRIPTION
This patch adds the ability to use xfs project quotas instead of gluster
quotas to constrain space consumption in the subvols. The xfs quotas
have a much lower performance overhead.

Signed-off-by: John Strunk <jstrunk@redhat.com>