### PR TITLE
Allow to skip fsGroup chown on kubernetes/okd

### DIFF
--- a/glfs-subvol/glfs-subvol
+++ b/glfs-subvol/glfs-subvol
@@ -64,7 +64,7 @@ function doInit() {
     if [[ "x$msg" != "x" ]] ; then
         result="{\"status\": \"Failure\", \"message\": \"${msg}\"}"
     else
-        result="{\"status\": \"Success\", \"capabilities\": {\"attach\": false, \"selinuxRelabel\": false}}"
+        result="{\"status\": \"Success\", \"capabilities\": {\"attach\": false, \"selinuxRelabel\": false, \"fsGroup\": false}}"
     fi
     retResult $RC_OK "$result"
 }


### PR DESCRIPTION
With this patch it's possible to disable fsGroup
https://github.com/kubernetes/kubernetes/pull/68680 for k8s 1.13
it is also merged on OKD https://github.com/openshift/origin/pull/21070 3.11.x

Fix https://github.com/gluster/gluster-subvol/issues/23