### PR TITLE
Send logs to container stdout

### DIFF
--- a/glfs-subvol/Dockerfile
+++ b/glfs-subvol/Dockerfile
@@ -2,7 +2,9 @@ FROM centos:7
 
 RUN yum update -y && \
     yum install -y \
+      logrotate \
       openssl \
+      rsyslog \
     && \
     yum clean all -y && \
     rm -rf /var/cache/yum
@@ -10,12 +12,13 @@ RUN yum update -y && \
 RUN curl -L https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 > /jq && \
     chmod a+x /jq
 
-RUN mkdir /flexpath && \
+RUN mkdir /etcssl && \
+    mkdir /flexpath && \
     mkdir /glusterd && \
-    mkdir /etcssl && \
+    mkdir /log && \
     mkdir /tlskeys
 
-COPY entry_flexvol.sh glfs-subvol /
+COPY entry_flexvol.sh entry_logrotate.sh entry_logtail.sh glfs-subvol /
 
 ARG builddate="(unknown)"
 ARG version="(unknown)"

--- a/glfs-subvol/entry_logrotate.sh
+++ b/glfs-subvol/entry_logrotate.sh
@@ -1,0 +1,34 @@
+#! /bin/bash
+
+set -e -o pipefail
+
+# Volumes that need to be mapped
+LOGDIR=/log
+# LOGFILE must be defined
+if [[ x"${LOGFILE}" == x ]]; then
+        echo "LOGFILE env variable must be defined"
+        exit 1
+fi
+
+# Create config file for logrotate
+cat - > /tmp/logrotate.conf <<EOF
+        "${LOGDIR}/${LOGFILE}" {
+                # Don't rotate, just truncate the file. This should avoid the
+                # need for HUP to glusterfs.
+                copytruncate
+
+                # It's ok if the log file doesn't exist
+                missingok
+
+                # Don't keep old files
+                rotate 0
+
+                # Take action when file exceeds 1 MB
+                size 1M
+        }
+EOF
+
+while true; do
+        logrotate -v -s /tmp/logrotate.state /tmp/logrotate.conf
+        sleep 600
+done

--- a/glfs-subvol/entry_logtail.sh
+++ b/glfs-subvol/entry_logtail.sh
@@ -1,0 +1,39 @@
+#! /bin/bash
+
+set -e -o pipefail
+
+# Volumes that need to be mapped
+LOGDIR=/log
+# LOGFILE must be defined
+if [[ x"${LOGFILE}" == x ]]; then
+        echo "LOGFILE env variable must be defined"
+        exit 1
+fi
+
+cat - > /tmp/rsyslog.conf <<CONF
+module(load="imfile"
+       Mode="inotify"
+       PollingInterval="10")
+input(type="imfile"
+      File="${LOGDIR}/*.log"
+      addMetadata="on"
+      freshStartTail="on"
+      reopenOnTruncate="on"
+      tag="logs")
+
+# This uses the legacy config format because the version in CentOS:7 doesn't
+# have the updated omstdout module that accepts the new config format.
+\$template outformat,"%TIMESTAMP:::date-rfc3339% %\$!metadata!filename%%msg:::sp-if-no-1st-sp%%msg:::drop-last-lf%\n"
+\$ModLoad omstdout
+*.* :omstdout:;outformat
+
+#template(name="outformat" type="string"
+#         string="%TIMESTAMP:::date-rfc3339% %\$!metadata!filename%%msg:::sp-if-no-1st-sp%%msg:::drop-last-lf%\n"
+#         )
+
+#module(load="omstdout")
+#action(type="omstdout"
+#       template="RSYSLOG_DebugFormat")
+CONF
+
+rsyslogd -n -f /tmp/rsyslog.conf

--- a/glfs-subvol/glfs-subvol
+++ b/glfs-subvol/glfs-subvol
@@ -20,7 +20,7 @@
 
 # if DEBUG, log everything to a file as we do it
 DEBUG=1
-DEBUGFILE='/tmp/glfs-subdir.out'
+DEBUGFILE='/var/log/glusterfs/glfs-subdir.log'
 TIME=$(date +%s.%N)
 
 RC_OK=0
@@ -31,6 +31,10 @@ scriptdir="$PWD"
 cd "$OLDPWD"
 MOUNTPATH=${scriptdir}/.mnt
 LOCKPATH=/var/lock/glfs-subvol
+
+if [[ $DEBUG -gt 0 ]]; then
+        mkdir -p "$(dirname "$DEBUGFILE")"
+fi
 
 #-- Make an entry in the log file (if enabled)
 function log() {
@@ -113,7 +117,7 @@ function doMount() {
         mountpoint -q $mountname
         if [[ $? != 0 ]]; then
             mkdir -p $mountname
-            execute mount -t glusterfs -o backup-volfile-servers=${backupservers} ${volserver}:/${volume} ${mountname}
+            execute mount -t glusterfs -o log-file="/var/log/glusterfs/${volserver}-${volume}.log",backup-volfile-servers=${backupservers} ${volserver}:/${volume} ${mountname}
         fi
         # bind must also be protected to ensure nobody unmounts before we
         # can bind

--- a/glfs-subvol/glfs-subvol
+++ b/glfs-subvol/glfs-subvol
@@ -201,8 +201,8 @@ if [[ $? -ne 0 || ! -x ${JQ} ]]; then
     rMessage="Unable to find 'jq' in PATH. Please install jq."
     retResult
 fi
-log "Using jq: ${JQ}"
-[[ -x "${JQ}" ]] || retResult "$S_FAILURE" "jq is not executable"
+[[ -x "${JQ}" ]] || retResult "$S_FAILURE" "jq ($JQ) is not executable"
+"${JQ}" . < /dev/null || retResult "$S_FAILURE" "Error running jq ($JQ)"
 
 which flock >& /dev/null
 if [[ $? -ne 0 ]]; then

--- a/gluster-subvol-operator/helm-charts/flexvol/templates/plugin-daemonset.yaml
+++ b/gluster-subvol-operator/helm-charts/flexvol/templates/plugin-daemonset.yaml
@@ -37,8 +37,33 @@ spec:
               mountPath: /etcssl
             - name: flexpath
               mountPath: /flexpath
-            - name: glusterd
+            - name: var-lib-glusterd
               mountPath: /glusterd
+        #-- Logrotate is disabled because the log files are written into
+        #-- /var/log/* and the logrotate on the host is resolnsible for
+        #-- managing data consumption there.
+        # - name: logrotate
+        #   image: {{ .Values.installerImage }}
+        #   command: [ "/entry_logrotate.sh" ]
+        #   securityContext:
+        #     runAsUser: 0
+        #   env:
+        #     - name: LOGFILE
+        #       value: "*.log"
+        #   volumeMounts:
+        #     - name: var-log-glusterfs
+        #      mountPath: /log
+        - name: logs
+          image: {{ .Values.installerImage }}
+          command: [ "/entry_logtail.sh" ]
+          securityContext:
+            runAsUser: 0
+          env:
+            - name: LOGFILE
+              value: "*.log"
+          volumeMounts:
+            - name: var-log-glusterfs
+              mountPath: /log
       terminationGracePeriodSeconds: 10
       volumes:
         {{ if .Values.tlsSecret -}}
@@ -54,9 +79,13 @@ spec:
           hostPath:
             path: {{ .Values.flexvolPath }}
             type: DirectoryOrCreate
-        - name: glusterd
+        - name: var-lib-glusterd
           hostPath:
-            path: /var/log/glusterd
+            path: /var/lib/glusterd
+            type: DirectoryOrCreate
+        - name: var-log-glusterfs
+          hostPath:
+            path: /var/log/glusterfs
             type: DirectoryOrCreate
   # Make sure DS pod stays running before continuing rollout
   minReadySeconds: 30


### PR DESCRIPTION
This adds a new container in the flex DS, "logs" that runs rsyslog to
send all gluster log files to the container's stdout.
There is also a logrotate container (currently inactive). The logrotate
container is not currently used because all log files are going into the
host's /var/log/* tree and getting rotated by the host's rotation
mechanisms.

- Flex plugin log has been changed to /var/log/glusterfs/glfs-subdir.log
(instead of /tmp/glfs-subdir.out).
- Fuse (glusterfs) supervol logfile is now set manually to be
/var/log/glusterfs/<serverip>-<volume>.log to shorten the filename and
make it easier to locate a particular supervol's log.

Fixes #33 