### PR TITLE
Add support for tolerations and affinity

### DIFF
--- a/gluster-subvol-operator/deploy/operator.yaml
+++ b/gluster-subvol-operator/deploy/operator.yaml
@@ -12,6 +12,22 @@ spec:
       labels:
         name: gluster-subvol-operator
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              # kube < 1.14 uses beta.kubernetes.io/os
+              - key: beta.kubernetes.io/os
+                operator: In
+                values:
+                - linux
+            - matchExpressions:
+              # kube >= 1.14 uses kubernetes.io/os
+              - key: kubernetes.io/os
+                operator: In
+                values:
+                - linux
       serviceAccountName: gluster-subvol-operator
       containers:
         - name: gluster-subvol-operator

--- a/gluster-subvol-operator/helm-charts/flexvol/templates/plugin-daemonset.yaml
+++ b/gluster-subvol-operator/helm-charts/flexvol/templates/plugin-daemonset.yaml
@@ -16,6 +16,10 @@ spec:
       labels:
         gluster-subvol-plugin: {{ include "flexvol.fullname" . }}
     spec:
+      {{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+      {{- end }}
       containers:
         - name: plugin-installer
           image: {{ .Values.installerImage }}
@@ -69,6 +73,10 @@ spec:
             - name: var-log-glusterfs
               mountPath: /log
       terminationGracePeriodSeconds: 10
+      {{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+      {{- end }}
       volumes:
         {{ if .Values.tlsSecret -}}
         - name: cakeys

--- a/gluster-subvol-operator/helm-charts/flexvol/values.yaml
+++ b/gluster-subvol-operator/helm-charts/flexvol/values.yaml
@@ -1,10 +1,18 @@
+# Affinity controls where the plugin can run
+# https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#node-affinity-beta-feature
+affinity: {}
+#  nodeAffinity:
+#    requiredDuringSchedulingIgnoredDuringExecution:
+#      nodeSelectorTerms:
+#        - matchExpressions:
+#            - key: gluster-flexvol
+#              operator: Exists
+
 # Set the directory (hostPath) where the flex plugin should be deployed
 # on the nodes
 flexvolPath: /usr/libexec/kubernetes/kubelet-plugins/volume/exec
 # Container image for the flexvol plugin installer
 installerImage: quay.io/gluster/gluster-subvol-plugin:latest
-# Node selector controls which nodes run the plugin
-nodeSelector: {}
 # Resource requests/limits
 resources:
   installer:

--- a/gluster-subvol-operator/helm-charts/flexvol/values.yaml
+++ b/gluster-subvol-operator/helm-charts/flexvol/values.yaml
@@ -1,12 +1,21 @@
 # Affinity controls where the plugin can run
 # https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#node-affinity-beta-feature
-affinity: {}
-#  nodeAffinity:
-#    requiredDuringSchedulingIgnoredDuringExecution:
-#      nodeSelectorTerms:
-#        - matchExpressions:
-#            - key: gluster-flexvol
-#              operator: Exists
+affinity:
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+      - matchExpressions:
+        # kube < 1.14 uses beta.kubernetes.io/os
+        - key: beta.kubernetes.io/os
+          operator: In
+          values:
+          - linux
+      - matchExpressions:
+        # kube >= 1.14 uses kubernetes.io/os
+        - key: kubernetes.io/os
+          operator: In
+          values:
+          - linux
 
 # Set the directory (hostPath) where the flex plugin should be deployed
 # on the nodes

--- a/gluster-subvol-operator/helm-charts/recycler/templates/recycler-deployment.yaml
+++ b/gluster-subvol-operator/helm-charts/recycler/templates/recycler-deployment.yaml
@@ -103,6 +103,10 @@ spec:
         app.kubernetes.io/managed-by: {{ .Release.Service }}
         helm.sh/chart: {{ include "recycler.chart" . }}
     spec:
+      {{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+      {{- end }}
       containers:
       - name: volrecycler
         image: {{ .Values.image }}
@@ -117,6 +121,10 @@ spec:
         - name: data
           mountPath: /data
       serviceAccount: {{ include "recycler.fullname" . }}
+      {{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+      {{- end }}
       volumes:
       - name: data
         persistentVolumeClaim:

--- a/gluster-subvol-operator/helm-charts/recycler/values.yaml
+++ b/gluster-subvol-operator/helm-charts/recycler/values.yaml
@@ -1,7 +1,15 @@
+# Affinity controls where the plugin can run
+# https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#node-affinity-beta-feature
+affinity: {}
+#  nodeAffinity:
+#    requiredDuringSchedulingIgnoredDuringExecution:
+#      nodeSelectorTerms:
+#        - matchExpressions:
+#            - key: gluster-flexvol
+#              operator: Exists
+
 # Container image for the subvol recycler
 image: quay.io/gluster/gluster-subvol-volrecycler:latest
-# Node selector controls which nodes can run the recyclers.
-nodeSelector: {}
 # Resource requests/limits
 resources:
   recycler:

--- a/gluster-subvol-operator/helm-charts/recycler/values.yaml
+++ b/gluster-subvol-operator/helm-charts/recycler/values.yaml
@@ -1,12 +1,21 @@
-# Affinity controls where the plugin can run
+# Affinity controls where the recyclers can run
 # https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#node-affinity-beta-feature
-affinity: {}
-#  nodeAffinity:
-#    requiredDuringSchedulingIgnoredDuringExecution:
-#      nodeSelectorTerms:
-#        - matchExpressions:
-#            - key: gluster-flexvol
-#              operator: Exists
+affinity:
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+      - matchExpressions:
+        # kube < 1.14 uses beta.kubernetes.io/os
+        - key: beta.kubernetes.io/os
+          operator: In
+          values:
+          - linux
+      - matchExpressions:
+        # kube >= 1.14 uses kubernetes.io/os
+        - key: kubernetes.io/os
+          operator: In
+          values:
+          - linux
 
 # Container image for the subvol recycler
 image: quay.io/gluster/gluster-subvol-volrecycler:latest


### PR DESCRIPTION
This adds support for affinity & tolerations in the CRs. It also, by default, applies a nodeAffinity that constrains all components to Linux hosts.

**Note:** If a user sets a custom affinity, it will override the default Linux constraint.

Fixes: #31 
Fixes: #45 