### PR TITLE
Add message that project is unmaintained.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # Overview
 
+**Project status:** (Mar 2020) The code in this repository is no longer under
+active development. If you are interested in helping to maintain this project,
+please open an issue or send mail to `gluster-devel@gluster.org`. Assuming no additional interest, this repo will be archived soon.
+
+------
+
 [![Build
 Status](https://travis-ci.org/gluster/gluster-subvol.svg?branch=master)](https://travis-ci.org/gluster/gluster-subvol)
 


### PR DESCRIPTION
I am no longer actively developing gluster-subvol, nor am I testing on current versions of kubernetes.

The flexvol driver is still in-use, so I'm not ready to archive the repo yet. But once that system is decomissioned, I plan to archive unless there is additional interest and contribution.